### PR TITLE
Make adl2edl use -rgb flag and specify a font file if EDMFONTFILE is set.

### DIFF
--- a/RULES_OPI
+++ b/RULES_OPI
@@ -34,9 +34,14 @@ $(UI_DIR)%.ui: $(ADL_DIR)%.adl
 endif
 
 ifdef ADL2EDL
+ifeq (,$(wildcard $(EDMFONTFILE)))
+	ADL2EDL_FONTS=''
+else
+	ADL2EDL_FONTS=-f $(EDMFONTFILE)
+endif
 EDLs := $(subst $(ADL_DIR),$(EDL_DIR),$(ADLs:.adl=.edl))
 $(EDL_DIR)%.edl: $(ADL_DIR)%.adl
-	$(ADL2EDL) $< $@
+	$(ADL2EDL) -rgb $(ADL2EDL_FONTS) $< $@
 endif
 
 ifdef CSS


### PR DESCRIPTION
Modified adl2edl invocation in RULES_OPI to use -rgb and specify font filename.

To specify an EDM font file, set env variable EDMFONTFILE to the full path to a
valid EDM version 3 font file.

Requires version 1.5 of adl2edl at https://github.com/epicsdeb/adl2edl